### PR TITLE
Escaped backslash in regex

### DIFF
--- a/init.py
+++ b/init.py
@@ -73,7 +73,7 @@ class StringValidator(Validator):
 class AccountIDValidator(Validator):
 
     def contains_symbols(self, value):
-        regex = re.compile('^\d{12}$')
+        regex = re.compile('^\\d{12}$')
         is_match = regex.match(value) is not None
         return is_match
 


### PR DESCRIPTION
I was getting an error 
EKS-Utils/init.py:74: SyntaxWarning: invalid escape sequence '\d'
  regex = re.compile('^\d{12}$')

A bit of background reading and it looks like backslashes are interpreted by Python as its own escaped string (rather than a literal to be passed to the regex function).  I think double escaping solves the problem.